### PR TITLE
Prevent warning by removing duplicate definition of `secure`.

### DIFF
--- a/templates/app/app.rb.tt
+++ b/templates/app/app.rb.tt
@@ -50,7 +50,6 @@ module <%= @name.camel_case %>
       set :sessions,
           httponly: true,
           secure: production?,
-          secure: false,
           expire_after: 5.years,
           secret: ENV['SESSION_SECRET']
     end


### PR DESCRIPTION
The application generated duplicates the `secure` setting which causes
the following warning:

    sample/app.rb:52: warning: key :secure is duplicated and overwritten on line 53